### PR TITLE
Improve responsive layout with scrollable tables

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -19,6 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { useApi } from "@/lib/hooks/useApi";
 
@@ -359,64 +360,68 @@ export default function DashboardPage() {
         </div>
         <Card>
           <CardContent className="px-0">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Process</TableHead>
-                  <TableHead>Active batches</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Efficiency</TableHead>
-                  <TableHead>Next action</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loadingProcesses && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                      Loading process data…
-                    </TableCell>
-                  </TableRow>
-                )}
+            <ScrollArea>
+              <div className="min-w-[680px] px-4">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Process</TableHead>
+                      <TableHead>Active batches</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Efficiency</TableHead>
+                      <TableHead>Next action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {loadingProcesses && (
+                      <TableRow>
+                        <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                          Loading process data…
+                        </TableCell>
+                      </TableRow>
+                    )}
 
-                {!loadingProcesses && (processError || batchError) && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center text-sm text-rose-600">
-                      Unable to load process overview. Please retry shortly.
-                    </TableCell>
-                  </TableRow>
-                )}
+                    {!loadingProcesses && (processError || batchError) && (
+                      <TableRow>
+                        <TableCell colSpan={5} className="text-center text-sm text-rose-600">
+                          Unable to load process overview. Please retry shortly.
+                        </TableCell>
+                      </TableRow>
+                    )}
 
-                {!loadingProcesses && !processError && !batchError && processRows.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                      No processes configured yet.
-                    </TableCell>
-                  </TableRow>
-                )}
+                    {!loadingProcesses && !processError && !batchError && processRows.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                          No processes configured yet.
+                        </TableCell>
+                      </TableRow>
+                    )}
 
-                {processRows.map((row) => (
-                  <TableRow key={row.process}>
-                    <TableCell className="font-medium">{row.process}</TableCell>
-                    <TableCell>{row.batches}</TableCell>
-                    <TableCell>
-                      <Badge
-                        variant="secondary"
-                        className={cn(
-                          "text-xs font-semibold",
-                          statusStyles[row.status] ?? "bg-slate-100 text-slate-700"
-                        )}
-                      >
-                        {row.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>{row.efficiency}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {row.nextAction}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                    {processRows.map((row) => (
+                      <TableRow key={row.process}>
+                        <TableCell className="font-medium">{row.process}</TableCell>
+                        <TableCell>{row.batches}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="secondary"
+                            className={cn(
+                              "text-xs font-semibold",
+                              statusStyles[row.status] ?? "bg-slate-100 text-slate-700"
+                            )}
+                          >
+                            {row.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{row.efficiency}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {row.nextAction}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </ScrollArea>
           </CardContent>
         </Card>
       </section>

--- a/app/(app)/job-cards/page.tsx
+++ b/app/(app)/job-cards/page.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
@@ -576,37 +577,41 @@ export default function JobCardsPage() {
                     {completedCards.length === 0 ? (
                       <p className="text-sm text-muted-foreground">No cards have been marked completed yet.</p>
                     ) : (
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead className="w-[140px]">Job card</TableHead>
-                            <TableHead>Output item</TableHead>
-                            <TableHead>Qty</TableHead>
-                            <TableHead>Completed on</TableHead>
-                            <TableHead>Last notes</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {completedCards.map((card) => {
-                            const completionTransaction = card.transactions?.find(
-                              (txn) => txn.type === "status" && txn.toStatus === "Completed"
-                            );
-                            return (
-                              <TableRow key={`completed-${filter}-${card.id}`}>
-                                <TableCell className="font-medium">{card.id}</TableCell>
-                                <TableCell>{card.outputItem}</TableCell>
-                                <TableCell>{card.quantity}</TableCell>
-                                <TableCell>
-                                  {completionTransaction ? formatDateTime(completionTransaction.timestamp) : "—"}
-                                </TableCell>
-                                <TableCell className="max-w-[220px] truncate">
-                                  {completionTransaction?.notes || "—"}
-                                </TableCell>
+                      <ScrollArea>
+                        <div className="min-w-[720px]">
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead className="w-[140px]">Job card</TableHead>
+                                <TableHead>Output item</TableHead>
+                                <TableHead>Qty</TableHead>
+                                <TableHead>Completed on</TableHead>
+                                <TableHead>Last notes</TableHead>
                               </TableRow>
-                            );
-                          })}
-                        </TableBody>
-                      </Table>
+                            </TableHeader>
+                            <TableBody>
+                              {completedCards.map((card) => {
+                                const completionTransaction = card.transactions?.find(
+                                  (txn) => txn.type === "status" && txn.toStatus === "Completed"
+                                );
+                                return (
+                                  <TableRow key={`completed-${filter}-${card.id}`}>
+                                    <TableCell className="font-medium">{card.id}</TableCell>
+                                    <TableCell>{card.outputItem}</TableCell>
+                                    <TableCell>{card.quantity}</TableCell>
+                                    <TableCell>
+                                      {completionTransaction ? formatDateTime(completionTransaction.timestamp) : "—"}
+                                    </TableCell>
+                                    <TableCell className="max-w-[220px] truncate">
+                                      {completionTransaction?.notes || "—"}
+                                    </TableCell>
+                                  </TableRow>
+                                );
+                              })}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      </ScrollArea>
                     )}
                   </CardContent>
                 </Card>
@@ -828,40 +833,44 @@ export default function JobCardsPage() {
                   </Button>
                 </div>
                 {activeCard && activeCard.transactions?.length ? (
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-[160px]">Timestamp</TableHead>
-                        <TableHead>Activity</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Process</TableHead>
-                        <TableHead>Weight in</TableHead>
-                        <TableHead>Weight out</TableHead>
-                        <TableHead>Notes</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {activeCard.transactions.map((txn, index) => (
-                        <TableRow key={`${activeCard.id}-txn-${index}`}>
-                          <TableCell>{formatDateTime(txn.timestamp)}</TableCell>
-                          <TableCell>{transactionTypeLabels[txn.type]}</TableCell>
-                          <TableCell>
-                            {txn.fromStatus === txn.toStatus
-                              ? txn.toStatus
-                              : `${txn.fromStatus} → ${txn.toStatus}`}
-                          </TableCell>
-                          <TableCell>
-                            {txn.fromProcess === txn.toProcess
-                              ? txn.toProcess
-                              : `${txn.fromProcess} → ${txn.toProcess}`}
-                          </TableCell>
-                          <TableCell>{txn.weightIn ?? "—"}</TableCell>
-                          <TableCell>{txn.weightOut ?? "—"}</TableCell>
-                          <TableCell className="max-w-[200px] whitespace-normal">{txn.notes ?? "—"}</TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
+                  <ScrollArea>
+                    <div className="min-w-[760px]">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-[160px]">Timestamp</TableHead>
+                            <TableHead>Activity</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead>Process</TableHead>
+                            <TableHead>Weight in</TableHead>
+                            <TableHead>Weight out</TableHead>
+                            <TableHead>Notes</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {activeCard.transactions.map((txn, index) => (
+                            <TableRow key={`${activeCard.id}-txn-${index}`}>
+                              <TableCell>{formatDateTime(txn.timestamp)}</TableCell>
+                              <TableCell>{transactionTypeLabels[txn.type]}</TableCell>
+                              <TableCell>
+                                {txn.fromStatus === txn.toStatus
+                                  ? txn.toStatus
+                                  : `${txn.fromStatus} → ${txn.toStatus}`}
+                              </TableCell>
+                              <TableCell>
+                                {txn.fromProcess === txn.toProcess
+                                  ? txn.toProcess
+                                  : `${txn.fromProcess} → ${txn.toProcess}`}
+                              </TableCell>
+                              <TableCell>{txn.weightIn ?? "—"}</TableCell>
+                              <TableCell>{txn.weightOut ?? "—"}</TableCell>
+                              <TableCell className="max-w-[200px] whitespace-normal">{txn.notes ?? "—"}</TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </ScrollArea>
                 ) : (
                   <p className="text-sm text-muted-foreground">No transactions captured yet. Log the first one to start the audit trail.</p>
                 )}

--- a/app/(app)/masters/page.tsx
+++ b/app/(app)/masters/page.tsx
@@ -56,6 +56,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tabs,
   TabsContent,
@@ -548,63 +549,67 @@ const ItemsSection = ({ onCreate, onEdit, onDelete }: ItemsSectionProps) => {
           </div>
         </div>
 
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>SKU</TableHead>
-              <TableHead>Item</TableHead>
-              <TableHead>Category</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="text-right">Updated</TableHead>
-              <TableHead className="w-[80px] text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {items.isLoading ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
-                  Loading items…
-                </TableCell>
-              </TableRow>
-            ) : items.error ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-rose-600">
-                  {items.error.message}
-                </TableCell>
-              </TableRow>
-            ) : filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
-                  No items match the current filters.
-                </TableCell>
-              </TableRow>
-            ) : (
-              filtered.map((item) => (
-                <TableRow key={item.id}>
-                  <TableCell className="font-medium">{item.sku}</TableCell>
-                  <TableCell>
-                    <div className="space-y-1">
-                      <p>{item.name}</p>
-                      <p className="text-xs text-muted-foreground">UOM: {item.unit}</p>
-                    </div>
-                  </TableCell>
-                  <TableCell>{item.category ?? "—"}</TableCell>
-                  <TableCell>
-                    <Badge variant="secondary" className={statusBadge[item.status ?? ""] ?? "border bg-muted text-muted-foreground"}>
-                      {item.status ?? "Unspecified"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right text-sm text-muted-foreground">
-                    {new Date(item.updated_at).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <RowActions onEdit={() => onEdit(item)} onDelete={() => onDelete(item)} />
-                  </TableCell>
+        <ScrollArea>
+          <div className="min-w-[760px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>SKU</TableHead>
+                  <TableHead>Item</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Updated</TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+              </TableHeader>
+              <TableBody>
+                {items.isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+                      Loading items…
+                    </TableCell>
+                  </TableRow>
+                ) : items.error ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-rose-600">
+                      {items.error.message}
+                    </TableCell>
+                  </TableRow>
+                ) : filtered.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+                      No items match the current filters.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filtered.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="font-medium">{item.sku}</TableCell>
+                      <TableCell>
+                        <div className="space-y-1">
+                          <p>{item.name}</p>
+                          <p className="text-xs text-muted-foreground">UOM: {item.unit}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell>{item.category ?? "—"}</TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className={statusBadge[item.status ?? ""] ?? "border bg-muted text-muted-foreground"}>
+                          {item.status ?? "Unspecified"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-muted-foreground">
+                        {new Date(item.updated_at).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <RowActions onEdit={() => onEdit(item)} onDelete={() => onDelete(item)} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </ScrollArea>
       </CardContent>
     </Card>
   );
@@ -694,58 +699,62 @@ const UomsSection = ({ onCreate, onEdit, onDelete }: UomsSectionProps) => {
           </div>
         </div>
 
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Code</TableHead>
-              <TableHead>Name</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead className="text-center">Precision</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead className="w-[80px] text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {uoms.isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
-                  Loading units…
-                </TableCell>
-              </TableRow>
-            ) : uoms.error ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center text-sm text-rose-600">
-                  {uoms.error.message}
-                </TableCell>
-              </TableRow>
-            ) : filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
-                  No units found for the current filters.
-                </TableCell>
-              </TableRow>
-            ) : (
-              filtered.map((unit) => (
-                <TableRow key={unit.id}>
-                  <TableCell className="font-medium uppercase">{unit.code}</TableCell>
-                  <TableCell>{unit.name}</TableCell>
-                  <TableCell>{unit.type ?? "—"}</TableCell>
-                  <TableCell className="text-center">{unit.precision ?? 0}</TableCell>
-                  <TableCell>
-                    <Badge variant="secondary" className={unit.is_active ? statusBadge.Active : statusBadge.Inactive}>
-                      {unit.is_active ? "Active" : "Inactive"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-sm text-muted-foreground">{unit.description ?? "—"}</TableCell>
-                  <TableCell className="text-right">
-                    <RowActions onEdit={() => onEdit(unit)} onDelete={() => onDelete(unit)} />
-                  </TableCell>
+        <ScrollArea>
+          <div className="min-w-[880px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Code</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead className="text-center">Precision</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+              </TableHeader>
+              <TableBody>
+                {uoms.isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                      Loading units…
+                    </TableCell>
+                  </TableRow>
+                ) : uoms.error ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-sm text-rose-600">
+                      {uoms.error.message}
+                    </TableCell>
+                  </TableRow>
+                ) : filtered.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                      No units found for the current filters.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filtered.map((unit) => (
+                    <TableRow key={unit.id}>
+                      <TableCell className="font-medium uppercase">{unit.code}</TableCell>
+                      <TableCell>{unit.name}</TableCell>
+                      <TableCell>{unit.type ?? "—"}</TableCell>
+                      <TableCell className="text-center">{unit.precision ?? 0}</TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className={unit.is_active ? statusBadge.Active : statusBadge.Inactive}>
+                          {unit.is_active ? "Active" : "Inactive"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">{unit.description ?? "—"}</TableCell>
+                      <TableCell className="text-right">
+                        <RowActions onEdit={() => onEdit(unit)} onDelete={() => onDelete(unit)} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </ScrollArea>
       </CardContent>
     </Card>
   );
@@ -847,56 +856,60 @@ const WorkersSection = ({ onCreate, onEdit, onDelete }: WorkersSectionProps) => 
           </div>
         </div>
 
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Code</TableHead>
-              <TableHead>Name</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead>Department</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="w-[80px] text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {workers.isLoading ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
-                  Loading workers…
-                </TableCell>
-              </TableRow>
-            ) : workers.error ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-rose-600">
-                  {workers.error.message}
-                </TableCell>
-              </TableRow>
-            ) : filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
-                  No workers match the current filters.
-                </TableCell>
-              </TableRow>
-            ) : (
-              filtered.map((worker) => (
-                <TableRow key={worker.id}>
-                  <TableCell className="font-medium uppercase">{worker.code}</TableCell>
-                  <TableCell>{worker.display_name}</TableCell>
-                  <TableCell>{worker.role ?? "—"}</TableCell>
-                  <TableCell>{worker.department ?? "—"}</TableCell>
-                  <TableCell>
-                    <Badge variant="secondary" className={statusBadge[worker.status ?? ""] ?? "border bg-muted text-muted-foreground"}>
-                      {worker.status ?? "Active"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <RowActions onEdit={() => onEdit(worker)} onDelete={() => onDelete(worker)} />
-                  </TableCell>
+        <ScrollArea>
+          <div className="min-w-[760px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Code</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Department</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+              </TableHeader>
+              <TableBody>
+                {workers.isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+                      Loading workers…
+                    </TableCell>
+                  </TableRow>
+                ) : workers.error ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-rose-600">
+                      {workers.error.message}
+                    </TableCell>
+                  </TableRow>
+                ) : filtered.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center text-sm text-muted-foreground">
+                      No workers match the current filters.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filtered.map((worker) => (
+                    <TableRow key={worker.id}>
+                      <TableCell className="font-medium uppercase">{worker.code}</TableCell>
+                      <TableCell>{worker.display_name}</TableCell>
+                      <TableCell>{worker.role ?? "—"}</TableCell>
+                      <TableCell>{worker.department ?? "—"}</TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className={statusBadge[worker.status ?? ""] ?? "border bg-muted text-muted-foreground"}>
+                          {worker.status ?? "Active"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <RowActions onEdit={() => onEdit(worker)} onDelete={() => onDelete(worker)} />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </ScrollArea>
       </CardContent>
     </Card>
   );
@@ -919,57 +932,61 @@ const ProcessesSection = ({ onCreate, onEdit, onDelete }: ProcessesSectionProps)
         </Button>
       </CardHeader>
       <CardContent className="space-y-4">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Sequence</TableHead>
-              <TableHead>Process</TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="w-[80px] text-right">Actions</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {processes.isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                  Loading processes…
-                </TableCell>
-              </TableRow>
-            ) : processes.error ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-sm text-rose-600">
-                  {processes.error.message}
-                </TableCell>
-              </TableRow>
-            ) : processes.records.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                  No processes captured yet.
-                </TableCell>
-              </TableRow>
-            ) : (
-              processes.records
-                .slice()
-                .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
-                .map((process) => (
-                  <TableRow key={process.id}>
-                    <TableCell className="text-sm text-muted-foreground">{process.sequence ?? "—"}</TableCell>
-                    <TableCell className="font-medium">{process.name}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">{process.description ?? "—"}</TableCell>
-                    <TableCell>
-                      <Badge variant="secondary" className={process.is_active ? statusBadge.Active : statusBadge.Inactive}>
-                        {process.is_active ? "Active" : "Inactive"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <RowActions onEdit={() => onEdit(process)} onDelete={() => onDelete(process)} />
+        <ScrollArea>
+          <div className="min-w-[720px]">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Sequence</TableHead>
+                  <TableHead>Process</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {processes.isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                      Loading processes…
                     </TableCell>
                   </TableRow>
-                ))
-            )}
-          </TableBody>
-        </Table>
+                ) : processes.error ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-sm text-rose-600">
+                      {processes.error.message}
+                    </TableCell>
+                  </TableRow>
+                ) : processes.records.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                      No processes captured yet.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  processes.records
+                    .slice()
+                    .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0))
+                    .map((process) => (
+                      <TableRow key={process.id}>
+                        <TableCell className="text-sm text-muted-foreground">{process.sequence ?? "—"}</TableCell>
+                        <TableCell className="font-medium">{process.name}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">{process.description ?? "—"}</TableCell>
+                        <TableCell>
+                          <Badge variant="secondary" className={process.is_active ? statusBadge.Active : statusBadge.Inactive}>
+                            {process.is_active ? "Active" : "Inactive"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <RowActions onEdit={() => onEdit(process)} onDelete={() => onDelete(process)} />
+                        </TableCell>
+                      </TableRow>
+                    ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </ScrollArea>
       </CardContent>
     </Card>
   );

--- a/app/(app)/stock-audit/page.tsx
+++ b/app/(app)/stock-audit/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useApi } from "@/lib/hooks/useApi";
 
 type ItemRecord = {
@@ -148,47 +149,51 @@ export default function StockAuditPage() {
           <CardDescription>Review the captured lines before requesting approval.</CardDescription>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Item</TableHead>
-                <TableHead className="text-center">System qty</TableHead>
-                <TableHead className="text-center">Physical qty</TableHead>
-                <TableHead>Difference</TableHead>
-                <TableHead>Location</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {mockSnapshots.map((line) => {
-                const masterRecord = items.find((record) => record.sku === line.code);
-                const diff = line.physical - line.system;
-                return (
-                  <TableRow key={line.code}>
-                    <TableCell className="font-medium">
-                      <div className="space-y-1">
-                        <p>{line.code}</p>
-                        {masterRecord ? (
-                          <>
-                            <p className="text-xs text-muted-foreground">{masterRecord.name}</p>
-                            <p className="text-xs text-muted-foreground">UOM: {masterRecord.unit}</p>
-                          </>
-                        ) : (
-                          <p className="text-xs text-muted-foreground">Unmapped in master</p>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-center">{line.system}</TableCell>
-                    <TableCell className="text-center">{line.physical}</TableCell>
-                    <TableCell className={diff === 0 ? "text-sm" : diff > 0 ? "text-sm text-emerald-600" : "text-sm text-rose-600"}>
-                      {diff > 0 ? "+" : ""}
-                      {diff}
-                    </TableCell>
-                    <TableCell>{line.location}</TableCell>
+          <ScrollArea>
+            <div className="min-w-[720px]">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Item</TableHead>
+                    <TableHead className="text-center">System qty</TableHead>
+                    <TableHead className="text-center">Physical qty</TableHead>
+                    <TableHead>Difference</TableHead>
+                    <TableHead>Location</TableHead>
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                </TableHeader>
+                <TableBody>
+                  {mockSnapshots.map((line) => {
+                    const masterRecord = items.find((record) => record.sku === line.code);
+                    const diff = line.physical - line.system;
+                    return (
+                      <TableRow key={line.code}>
+                        <TableCell className="font-medium">
+                          <div className="space-y-1">
+                            <p>{line.code}</p>
+                            {masterRecord ? (
+                              <>
+                                <p className="text-xs text-muted-foreground">{masterRecord.name}</p>
+                                <p className="text-xs text-muted-foreground">UOM: {masterRecord.unit}</p>
+                              </>
+                            ) : (
+                              <p className="text-xs text-muted-foreground">Unmapped in master</p>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-center">{line.system}</TableCell>
+                        <TableCell className="text-center">{line.physical}</TableCell>
+                        <TableCell className={diff === 0 ? "text-sm" : diff > 0 ? "text-sm text-emerald-600" : "text-sm text-rose-600"}>
+                          {diff > 0 ? "+" : ""}
+                          {diff}
+                        </TableCell>
+                        <TableCell>{line.location}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </ScrollArea>
         </CardContent>
         <CardFooter className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
           <Button variant="outline">Export draft</Button>

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useApi } from "@/lib/hooks/useApi";
 
 const formGuide = [
@@ -277,56 +278,60 @@ export default function TransactionsPage() {
           </Button>
         </CardHeader>
         <CardContent className="px-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Batch</TableHead>
-                <TableHead>Process</TableHead>
-                <TableHead>Started</TableHead>
-                <TableHead>Supervisor</TableHead>
-                <TableHead>Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {batchesLoading && (
-                <TableRow>
-                  <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                    Loading batches…
-                  </TableCell>
-                </TableRow>
-              )}
-              {batchError && !batchesLoading && (
-                <TableRow>
-                  <TableCell colSpan={5} className="text-center text-sm text-rose-600">
-                    Failed to load batches. Please try again.
-                  </TableCell>
-                </TableRow>
-              )}
-              {!batchesLoading && !batchError && openBatches.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
-                    No active batches yet. Create one to get started.
-                  </TableCell>
-                </TableRow>
-              )}
-              {openBatches.map((batch) => (
-                <TableRow key={batch.rawId}>
-                  <TableCell className="font-medium">{batch.id}</TableCell>
-                  <TableCell>{batch.process}</TableCell>
-                  <TableCell>{batch.started}</TableCell>
-                  <TableCell>{batch.supervisor}</TableCell>
-                  <TableCell>
-                    <Badge
-                      variant={batch.status === "Paused" ? "destructive" : "secondary"}
-                      className="font-medium"
-                    >
-                      {batch.status}
-                    </Badge>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <ScrollArea>
+            <div className="min-w-[640px] px-4">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Batch</TableHead>
+                    <TableHead>Process</TableHead>
+                    <TableHead>Started</TableHead>
+                    <TableHead>Supervisor</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {batchesLoading && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                        Loading batches…
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {batchError && !batchesLoading && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center text-sm text-rose-600">
+                        Failed to load batches. Please try again.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {!batchesLoading && !batchError && openBatches.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                        No active batches yet. Create one to get started.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {openBatches.map((batch) => (
+                    <TableRow key={batch.rawId}>
+                      <TableCell className="font-medium">{batch.id}</TableCell>
+                      <TableCell>{batch.process}</TableCell>
+                      <TableCell>{batch.started}</TableCell>
+                      <TableCell>{batch.supervisor}</TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={batch.status === "Paused" ? "destructive" : "secondary"}
+                          className="font-medium"
+                        >
+                          {batch.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </ScrollArea>
         </CardContent>
       </Card>
 

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -18,8 +18,8 @@ export function TopBar() {
   const { collapsed, setCollapsed } = useSidebar();
 
   return (
-    <header className="flex items-center justify-between border-b bg-card px-4 py-3 lg:px-8">
-      <div className="flex items-center gap-3">
+    <header className="flex flex-wrap items-center justify-between gap-3 border-b bg-card px-4 py-3 lg:px-8">
+      <div className="flex min-w-0 items-center gap-3">
         <Sheet onOpenChange={(open) => open && setCollapsed(false)}>
           <SheetTrigger asChild>
             <Button
@@ -43,7 +43,7 @@ export function TopBar() {
           {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
         </SidebarTrigger>
 
-        <div className="space-y-0.5">
+        <div className="min-w-0 space-y-0.5">
           <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             Operations command center
           </p>
@@ -53,14 +53,24 @@ export function TopBar() {
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex w-full flex-wrap items-center justify-end gap-3 sm:w-auto">
         <Button variant="outline" size="sm" className="hidden md:flex">
           View shift plan
         </Button>
         <Button size="sm" className="hidden md:flex">
           Log production
         </Button>
-        <div className="flex items-center gap-3 rounded-full border bg-card px-3 py-1.5">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-9 w-9 rounded-full border border-dashed sm:hidden"
+          aria-label="View profile"
+        >
+          <Avatar className="h-7 w-7">
+            <AvatarFallback>SS</AvatarFallback>
+          </Avatar>
+        </Button>
+        <div className="hidden items-center gap-3 rounded-full border bg-card px-3 py-1.5 sm:flex">
           <Avatar className="h-9 w-9">
             <AvatarFallback>SS</AvatarFallback>
           </Avatar>

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ScrollArea = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, children, ...props }, ref) => (
+    <div ref={ref} className={cn("relative overflow-hidden", className)} {...props}>
+      <div className="overflow-x-auto">{children}</div>
+    </div>
+  )
+);
+ScrollArea.displayName = "ScrollArea";
+
+export { ScrollArea };


### PR DESCRIPTION
## Summary
- add a lightweight scroll area wrapper for horizontal overflow
- rework the top bar layout so actions and profile controls adapt on mobile
- wrap wide data tables across dashboard, transactions, job cards, masters, and stock audit pages with the scroll area helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ceb94d0d3c832382d4f220a586194f